### PR TITLE
Provide one version of Poller<T> and Registrar<T>

### DIFF
--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -13,16 +13,16 @@ use registration::Registration;
 
 static EPOLL_EVENT_SIZE: usize = 1024;
 
-pub struct Poller<T> {
+pub struct KernelPoller<T> {
     epfd: RawFd,
     registrar: Registrar<T>,
     events: Vec<EpollEvent>
 }
 
-impl<T> Poller<T> {
-    pub fn new() -> Result<Poller<T>> {
+impl<T> KernelPoller<T> {
+    pub fn new() -> Result<KernelPoller<T>> {
         let epfd = try!(epoll_create());
-        Ok(Poller {
+        Ok(KernelPoller {
             epfd: epfd,
             registrar: Registrar::new(epfd),
             events: Vec::with_capacity(EPOLL_EVENT_SIZE)
@@ -90,7 +90,7 @@ pub struct Registrar<T> {
     epfd: RawFd,
 
     // We use PhantomData here so that this type logically requires being tied to type T.
-    // Since the Registrar is tied to the Poller, which stores data of type T, we want to ensure
+    // Since the Registrar is tied to the KernelPoller, which stores data of type T, we want to ensure
     // that when we register data, we only register data of type T.
     // See https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters
     phantom: PhantomData<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,22 +6,19 @@ mod registration;
 mod event;
 mod notification;
 mod line_reader;
+mod poller;
+mod registrar;
+
+pub use poller::Poller;
+pub use registrar::Registrar;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod epoll;
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
-pub use epoll::{Poller, Registrar};
 
 #[cfg(any(target_os = "bitrig", target_os = "dragonfly",
           target_os = "freebsd", target_os = "ios", target_os = "macos",
           target_os = "netbsd", target_os = "openbsd"))]
 mod kqueue;
-
-#[cfg(any(target_os = "bitrig", target_os = "dragonfly",
-          target_os = "freebsd", target_os = "ios", target_os = "macos",
-          target_os = "netbsd", target_os = "openbsd"))]
-pub use kqueue::{Poller, Registrar};
 
 pub use socket::Socket;
 pub use registration::Registration;

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -1,0 +1,52 @@
+use nix::Result;
+
+use registrar::Registrar;
+use notification::Notification;
+use socket::Socket;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use epoll::KernelPoller;
+
+#[cfg(any(target_os = "bitrig", target_os = "dragonfly",
+          target_os = "freebsd", target_os = "ios", target_os = "macos",
+          target_os = "netbsd", target_os = "openbsd"))]
+pub use kqueue::KernelPoller;
+
+/// A Poller is an abstraction around a kernel I/O poller. Kernel pollers are platform specific.
+///
+/// A Poller is tied to a Registrar of the same type. The registrar allows registering file
+/// descriptors with the poller, while the poller waits for read or write events on those file
+/// descriptors.
+pub struct Poller<T> {
+    registrar: Registrar<T>,
+    inner: KernelPoller<T>
+}
+
+impl<T> Poller<T> {
+    pub fn new() -> Result<Poller<T>> {
+        let inner = try!(KernelPoller::new());
+        Ok(Poller {
+            registrar: Registrar::new(inner.get_registrar()),
+            inner: inner
+        })
+    }
+
+    /// Return a Registrar that can be used to register Sockets with a Poller.
+    ///
+    /// Registrars are cloneable and can be used on a different thread from the Poller.
+    pub fn get_registrar(&self) -> Registrar<T> {
+        self.registrar.clone()
+    }
+
+    /// Wait for notifications from the Poller
+    pub fn wait(&mut self, timeout_ms: usize) -> Result<Vec<Notification<T>>> {
+        self.inner.wait(timeout_ms)
+    }
+
+    // TODO: I'd like to configure this for tests only, but it doesn't compile properly
+    // #[cfg(test)]
+    #[doc(hidden)]
+    pub fn assert_fail_to_delete(&self, socket: Socket) {
+        self.inner.assert_fail_to_delete(socket)
+    }
+}

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -1,0 +1,49 @@
+use nix::Result;
+use socket::Socket;
+use event::Event;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use epoll::KernelRegistar;
+
+#[cfg(any(target_os = "bitrig", target_os = "dragonfly",
+          target_os = "freebsd", target_os = "ios", target_os = "macos",
+          target_os = "netbsd", target_os = "openbsd"))]
+pub use kqueue::KernelRegistrar;
+
+#[derive(Debug)]
+/// An abstraction for registering file descriptors with a kernel poller
+///
+/// A Registrar is tied to a Poller of the same type, and registers Sockets and user data that will
+/// then be waited on by the Poller. A Registar should only be retrieved via a call to
+/// Poller::get_registrar(&self), and not created on it's own.
+pub struct Registrar<T> {
+    inner: KernelRegistrar<T>
+}
+
+impl<T> Registrar<T> {
+    /// This method is public only so it can be used directly by the Poller. Do not Use it.
+    #[doc(hidden)]
+    pub fn new(inner: KernelRegistrar<T>) -> Registrar<T> {
+        Registrar {
+            inner: inner
+        }
+    }
+
+    /// Register a socket and aribtrary user data for a given event type, with a Poller.
+    ///
+    /// Note that only a single type of user data can be used with a given Poller/Registrar pair.
+    pub fn register(&self, sock: Socket, event: Event, user_data: T) -> Result<()> {
+        self.inner.register(sock, event, user_data)
+    }
+}
+
+//  We impl clone instead of deriving it because T is not cloneable. This works fine because T is
+//  PhantomData in the KernelRegistrar
+impl<T> Clone for Registrar<T> {
+    fn clone(&self) -> Registrar<T> {
+        Registrar {
+            inner: self.inner.clone()
+        }
+    }
+
+}


### PR DESCRIPTION
In order to document the interface in rustdoc in a single spot, rename the
platform specific code to KernelPoller and KernelRegistrar. Poller<T>
and Registrar<T> now wrap the platform specific code.
