### PR TITLE
Add pollable channel receiver support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,8 @@ keywords = ["async", "epoll", "kqueue", "eventloop", "timer"]
 license = "Apache-2.0"
 
 [dependencies]
-nix = "0.5.0"
 libc = "0.2"
+
+[dependencies.nix]
+version = "0.6"
+features = ["eventfd"]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,178 @@
+use std::sync::{mpsc, Arc};
+use std::fmt::Debug;
+use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use user_event::UserEvent;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use epoll::KernelRegistrar;
+
+#[cfg(any(target_os = "bitrig", target_os = "dragonfly",
+          target_os = "freebsd", target_os = "ios", target_os = "macos",
+          target_os = "netbsd", target_os = "openbsd"))]
+pub use kqueue::KernelRegistrar;
+
+pub fn channel<T: Debug>(mut registrar: KernelRegistrar) -> io::Result<(Sender<T>, Receiver<T>)> {
+    let (tx, rx) = mpsc::channel();
+    let pending = Arc::new(AtomicUsize::new(0));
+    let user_event = try!(registrar.register_user_event().map_err(|e| io::Error::from(e)));
+
+    let tx = Sender {
+        tx: tx,
+        user_event: user_event.clone(),
+        pending: pending.clone()
+    };
+
+    let rx = Receiver {
+        rx: rx,
+        user_event: user_event,
+        pending: pending,
+        registrar: registrar
+    };
+
+    Ok((tx, rx))
+}
+
+pub fn sync_channel<T: Debug>(mut registrar: KernelRegistrar,
+                              bound: usize) -> io::Result<(SyncSender<T>, Receiver<T>)> {
+    let (tx, rx) = mpsc::sync_channel(bound);
+    let pending = Arc::new(AtomicUsize::new(0));
+    let user_event = try!(registrar.register_user_event().map_err(|e| io::Error::from(e)));
+
+    let tx = SyncSender {
+        tx: tx,
+        user_event: user_event.clone(),
+        pending: pending.clone()
+    };
+
+    let rx = Receiver {
+        rx: rx,
+        user_event: user_event,
+        pending: pending,
+        registrar: registrar
+    };
+
+    Ok((tx, rx))
+}
+
+
+#[derive(Debug, Clone)]
+pub struct Sender<T: Debug> {
+    tx: mpsc::Sender<T>,
+    user_event: UserEvent,
+    pending: Arc<AtomicUsize>
+}
+
+impl<T: Debug> Sender<T> {
+    pub fn send(&self, msg: T) -> Result<(), ChannelError<T>> {
+        try!(self.tx.send(msg));
+        if self.pending.fetch_add(1, Ordering::SeqCst) == 0 {
+            // Notify the kernel poller that a read is ready
+            try!(self.user_event.trigger());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SyncSender<T: Debug> {
+    tx: mpsc::SyncSender<T>,
+    user_event: UserEvent,
+    pending: Arc<AtomicUsize>
+}
+
+impl<T: Debug> SyncSender<T> {
+    pub fn send(&self, msg: T) -> Result<(), ChannelError<T>> {
+        try!(self.tx.send(msg));
+        if self.pending.fetch_add(1, Ordering::SeqCst) == 0 {
+            // Notify the kernel poller that a read is ready
+            try!(self.user_event.trigger());
+        }
+        Ok(())
+    }
+
+    pub fn try_send(&self, msg: T) -> Result<(), ChannelError<T>> {
+        try!(self.tx.try_send(msg));
+        if self.pending.fetch_add(1, Ordering::SeqCst) == 0 {
+            // Notify the kernel poller that a read is ready
+            try!(self.user_event.trigger());
+        }
+        Ok(())
+    }
+}
+
+pub struct Receiver<T: Debug> {
+    rx: mpsc::Receiver<T>,
+    user_event: UserEvent,
+    pending: Arc<AtomicUsize>,
+    registrar: KernelRegistrar
+}
+
+impl<T: Debug> Receiver<T> {
+    pub fn try_recv(&self) -> Result<T, ChannelError<T>> {
+        if self.pending.load(Ordering::SeqCst) == 0 {
+            // Clear the kernel event and prepare for edge triggering
+            try!(self.user_event.clear());
+
+            // Try one last check to prevent a race condition where the sender puts a value on the
+            // channel and writes the event after our pending.load check, but before we did the
+            // read. If we just did a read this would result in a value remaining on the channel and
+            // a poller that would never wake up.
+            if self.pending.load(Ordering::SeqCst) == 0 {
+                return Err(ChannelError::TryRecvError(mpsc::TryRecvError::Empty));
+            }
+            // We still have pending events, re-activate the user event so the poller will wakeup
+            try!(self.user_event.trigger());
+        }
+
+        self.pending.fetch_sub(1, Ordering::SeqCst);
+        self.rx.try_recv().map_err(|e| ChannelError::from(e))
+    }
+
+    pub fn get_id(&self) -> usize {
+        self.user_event.id
+    }
+}
+
+impl<T: Debug> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        // Don't leak file descriptors. Note that the tx side will never get notified that the rx
+        // side is gone, so senders can leak. However, any attempt to send from a sender will show
+        // the receiver to be disconnected, so they can be cleaned up then, or ahead of time if it's
+        // known that the channel is going away.
+        let _ = self.registrar.deregister_user_event(self.user_event.clone());
+    }
+}
+
+#[derive(Debug)]
+pub enum ChannelError<T: Debug> {
+    SendError(mpsc::SendError<T>),
+    TrySendError(mpsc::TrySendError<T>),
+    TryRecvError(mpsc::TryRecvError),
+    Io(io::Error)
+}
+
+impl<T: Debug> From<io::Error> for ChannelError<T> {
+    fn from(e: io::Error) -> ChannelError<T> {
+        ChannelError::Io(e)
+    }
+}
+
+impl<T: Debug> From<mpsc::SendError<T>> for ChannelError<T> {
+    fn from(e: mpsc::SendError<T>) -> ChannelError<T> {
+        ChannelError::SendError(e)
+    }
+}
+
+impl<T: Debug> From<mpsc::TrySendError<T>> for ChannelError<T> {
+    fn from(e: mpsc::TrySendError<T>) -> ChannelError<T> {
+        ChannelError::TrySendError(e)
+    }
+}
+
+impl<T: Debug> From<mpsc::TryRecvError> for ChannelError<T> {
+    fn from(e: mpsc::TryRecvError) -> ChannelError<T> {
+        ChannelError::TryRecvError(e)
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ mod frame_writer;
 mod poller;
 mod registrar;
 mod timer;
+mod user_event;
+mod channel;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod epoll;
@@ -28,3 +30,4 @@ pub use line_reader::LineReader;
 pub use frame_reader::FrameReader;
 pub use frame_writer::FrameWriter;
 pub use timer::Timer;
+pub use channel::{channel, Sender, Receiver};

--- a/src/user_event.rs
+++ b/src/user_event.rs
@@ -1,0 +1,99 @@
+use std::os::unix::io::{RawFd, AsRawFd};
+use std::io::{Result, Error};
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::mem;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use libc;
+
+/// An opaque handle to a user level event.
+///
+/// On Linux this contains a file descriptor created with
+/// [eventfd()](http://man7.org/linux/man-pages/man2/eventfd.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[derive(Debug, Clone)]
+pub struct UserEvent {
+    #[doc(hidden)]
+    pub id: usize,
+
+    #[doc(hidden)]
+    pub fd: RawFd
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl UserEvent {
+    pub fn get_id(&self) -> usize {
+        self.id
+    }
+
+    pub fn clear(&self) -> Result<()> {
+        let buf: u64 = 0;
+        unsafe {
+            let ptr: *mut libc::c_void = mem::transmute(&buf);
+            if libc::read(self.fd, ptr, 8) < 0 {
+                return Err(Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+
+    pub fn trigger(&self) -> Result<()> {
+        let buf: u64 = 1;
+        unsafe {
+            let ptr: *const libc::c_void = mem::transmute(&buf);
+            if libc::write(self.fd, ptr, 8) < 0 {
+                return Err(Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl AsRawFd for UserEvent {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+/* NON LINUX SYSTEMS */
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+pub use kqueue::KernelRegistrar;
+
+/// An opaque handle to a user level event.
+///
+/// On Kqueue base systems there is no file descriptor
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[derive(Debug, Clone)]
+pub struct UserEvent {
+    #[doc(hidden)]
+    pub id: usize,
+
+    #[doc(hidden)]
+    pub registrar: KernelRegistrar
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+impl UserEvent {
+    pub fn get_id(&self) -> usize {
+        self.id
+    }
+
+    // Nothing to do on Kqueue based systems
+    pub fn clear(&self) -> Result<()> {
+        self.registrar.clear_user_event(&self).map_err(|e| Error::from(e))
+    }
+
+    pub fn trigger(&self) -> Result<()> {
+        self.registrar.trigger_user_event(&self).map_err(|e| Error::from(e))
+    }
+}
+
+// We don't actually need a RawFd for kqueue and don't want to shrink the id size from usize to i32
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+impl AsRawFd for UserEvent {
+    fn as_raw_fd(&self) -> RawFd {
+        0
+    }
+}

--- a/tests/channel_test.rs
+++ b/tests/channel_test.rs
@@ -1,0 +1,153 @@
+/// Test Channels where the receiver is pollable
+
+extern crate amy;
+
+use amy::{Poller, Event};
+
+#[test]
+fn send_wakes_poller() {
+    let mut poller = Poller::new().unwrap();
+    let registrar = poller.get_registrar();
+    let (tx, rx) = registrar.channel().unwrap();
+
+    // no notifications if nothing is registered
+    let notifications = poller.wait(50).unwrap();
+    assert_eq!(0, notifications.len());
+
+    // Send causes the poller to wakeup
+    tx.send("a").unwrap();
+
+    // We poll and get a notification that there is something to receive and receive the sent value
+    let notifications = poller.wait(5000).unwrap();
+    assert_eq!(1, notifications.len());
+    assert_eq!(rx.get_id(), notifications[0].id);
+    assert_eq!(Event::Read, notifications[0].event);
+    assert_eq!("a", rx.try_recv().unwrap());
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn multiple_sends_wake_poller_once() {
+    let mut poller = Poller::new().unwrap();
+    let registrar = poller.get_registrar();
+    let (tx, rx) = registrar.channel().unwrap();
+
+    tx.send("a").unwrap();
+    tx.send("b").unwrap();
+
+    let notifications = poller.wait(5000).unwrap();
+    assert_eq!(1, notifications.len());
+    assert_eq!(rx.get_id(), notifications[0].id);
+    assert_eq!("a", rx.try_recv().unwrap());
+    assert_eq!("b", rx.try_recv().unwrap());
+
+    let notifications = poller.wait(50).unwrap();
+    assert_eq!(0, notifications.len());
+}
+
+#[test]
+fn send_before_poll_and_after_poll_but_before_recv_only_wakes_poller_once() {
+    let mut poller = Poller::new().unwrap();
+    let registrar = poller.get_registrar();
+    let (tx, rx) = registrar.channel().unwrap();
+
+    tx.send("a").unwrap();
+
+    let notifications = poller.wait(5000).unwrap();
+    assert_eq!(1, notifications.len());
+    assert_eq!(rx.get_id(), notifications[0].id);
+
+    // We haven't done a receive yet, so this just increments the atomic counter instead of
+    // triggering the poll wakeup. This is an optimization since atomic counters are much cheaper
+    // than syscalls.
+    tx.send("b").unwrap();
+
+    assert_eq!("a", rx.try_recv().unwrap());
+    assert_eq!("b", rx.try_recv().unwrap());
+
+    let notifications = poller.wait(50).unwrap();
+    assert_eq!(0, notifications.len());
+}
+
+#[test]
+fn send_after_receive_after_poll_followed_by_recv_wakes_poller_again() {
+    let mut poller = Poller::new().unwrap();
+    let registrar = poller.get_registrar();
+    let (tx, rx) = registrar.channel().unwrap();
+
+    tx.send("a").unwrap();
+
+    let notifications = poller.wait(5000).unwrap();
+    assert_eq!(1, notifications.len());
+    assert_eq!(rx.get_id(), notifications[0].id);
+    assert_eq!("a", rx.try_recv().unwrap());
+
+    // At this point we did a receive so the atomic pending counter is reduced to zero again. Any
+    // new send will trigger a state change on the file descriptor. This will cause the poller to
+    // wakeup. A single recv will just decrement the counter, but not call a subsequent clear,
+    // so the receiver will remain readable and wake the poller. Clear is only called when
+    // rx.try_recv() is called one more time.
+
+    tx.send("b").unwrap();
+    assert_eq!("b", rx.try_recv().unwrap());
+    let notifications = poller.wait(1000).unwrap();
+    assert_eq!(1, notifications.len());
+    assert_eq!(rx.get_id(), notifications[0].id);
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn send_after_receive_after_poll_followed_by_recv_until_err_doesnt_wake_polller_again() {
+    let mut poller = Poller::new().unwrap();
+    let registrar = poller.get_registrar();
+    let (tx, rx) = registrar.channel().unwrap();
+
+    tx.send("a").unwrap();
+
+    let notifications = poller.wait(5000).unwrap();
+    assert_eq!(1, notifications.len());
+    assert_eq!(rx.get_id(), notifications[0].id);
+    assert_eq!("a", rx.try_recv().unwrap());
+
+    // At this point we did a receive so the atomic pending counter is reduced to zero again. Any
+    // new send will trigger a state change on the file descriptor. This will cause the poller to
+    // wakeup. However, if we do another receive, there will be nothing to receive since the
+    // counter is 0. This will result in a clear on the file descriptor which will make it no
+    // longer readable and therefore not wake the poller.
+
+    tx.send("b").unwrap();
+    assert_eq!("b", rx.try_recv().unwrap());
+    assert!(rx.try_recv().is_err());
+    let notifications = poller.wait(50).unwrap();
+    assert_eq!(0, notifications.len());
+}
+
+#[test]
+fn simple_sync_channel_test() {
+    let mut poller = Poller::new().unwrap();
+    let registrar = poller.get_registrar();
+    let (tx, rx) = registrar.sync_channel(1).unwrap();
+
+    // no notifications if nothing is registered
+    let notifications = poller.wait(50).unwrap();
+    assert_eq!(0, notifications.len());
+
+    // Send causes the poller to wakeup
+    tx.send("a").unwrap();
+
+    // We poll and get a notification that there is something to receive and receive the sent value
+    let notifications = poller.wait(5000).unwrap();
+    assert_eq!(1, notifications.len());
+    assert_eq!(rx.get_id(), notifications[0].id);
+    assert_eq!(Event::Read, notifications[0].event);
+
+    // Send should fail because buffer is of size 1
+    tx.try_send("b").is_err();
+
+    assert_eq!("a", rx.try_recv().unwrap());
+    assert!(rx.try_recv().is_err());
+
+    // Send should succeed because we received the previous value
+    tx.try_send("b").unwrap();
+    assert_eq!("b", rx.try_recv().unwrap());
+}

--- a/tests/multithread-example.rs
+++ b/tests/multithread-example.rs
@@ -87,7 +87,7 @@ fn run_poller(mut poller: Poller, tx: Sender<Notification>) {
     assert_eq!(1, notifications.len());
     let notification = notifications.pop().unwrap();
     assert_eq!(Event::Read, notification.event);
-    assert_eq!(1, notification.id);
+    assert_eq!(0, notification.id);
 
     tx.send(notification).unwrap();
 
@@ -98,7 +98,7 @@ fn run_poller(mut poller: Poller, tx: Sender<Notification>) {
     assert_eq!(1, notifications.len());
     let notification = notifications.pop().unwrap();
     assert_eq!(Event::Read, notification.event);
-    assert_eq!(2, notification.id);
+    assert_eq!(1, notification.id);
 
     // Forward the notification to the worker
     tx.send(notification).unwrap();
@@ -111,7 +111,7 @@ fn run_poller(mut poller: Poller, tx: Sender<Notification>) {
     assert_eq!(1, notifications.len());
     let notification = notifications.pop().unwrap();
     assert_eq!(Event::Write, notification.event);
-    assert_eq!(2, notification.id);
+    assert_eq!(1, notification.id);
 
     // Forward the notification to the worker
     tx.send(notification).unwrap();
@@ -126,7 +126,7 @@ fn run_worker(registrar: Registrar, rx: Receiver<Notification>, listener: TcpLis
 
     let listener_id = registrar.register(&listener, Event::Read).unwrap();
     // This is the first registered socket, so it's Id is 1
-    assert_eq!(listener_id, 1);
+    assert_eq!(0, listener_id);
 
     // 1) Wait for a connection from the client to be noticed by the poller against the registered
     // listening socket. Then accept the connection and register it.
@@ -139,7 +139,7 @@ fn run_worker(registrar: Registrar, rx: Receiver<Notification>, listener: TcpLis
     socket.set_nonblocking(true).unwrap();
     let socket_id = registrar.register(&socket, Event::Read).unwrap();
     // This is the second registration of a socket, so it's Id is 2.
-    assert_eq!(2, socket_id);
+    assert_eq!(1, socket_id);
 
     // 2) Data was received on the socket from the client, the read event was handled by the poller
     // and forwarded to this worker.


### PR DESCRIPTION
Async and sync channel receivers can now be polled by epoll/kqueue.
Since syscalls are very expensive and are used for user level
notifications in both kqueue and epoll, we reduce the need for them.
This is accomplished via an atomic `pending` counter that gets
incremented on every send and decremented on every receive. When the
counter is 0 during either a send or receive, a syscall will be made to
trigger or clear the event in the kernel poller respectively.

Note that the above optimization only helps when there are multiple
sends between polls on the same channel. It is therefore more efficient
to use a single channel between the poller and sending thread than
multiple channels.