### PR TITLE
Fix FrameReader::read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amy"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Andrew J. Stone <andrew.j.stone.1@gmail.com>"]
 description = "Polling and Registration abstractions around kqueue and epoll for multithreaded async network programming"
 repository = "https://github.com/andrewjstone/amy"
@@ -13,3 +13,6 @@ libc = "0.2"
 [dependencies.nix]
 version = "0.6"
 features = ["eventfd"]
+
+[dev-dependencies]
+assert_matches = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 extern crate libc;
 extern crate nix;
 
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
+
 mod event;
 mod notification;
 mod line_reader;


### PR DESCRIPTION
 * Don't return an error when 0 bytes are read
 * Return Ok(total_bytes_read) on EWOULDBLOCK or EAGAIN instead of returning an error