### PR TITLE
Ensure user events get retriggered after clear

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amy"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["Andrew J. Stone <andrew.j.stone.1@gmail.com>"]
 description = "Polling and Registration abstractions around kqueue and epoll for multithreaded async network programming"
 repository = "https://github.com/andrewjstone/amy"

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::os::unix::io::AsRawFd;
 use nix::sys::event::{kqueue, kevent, KEvent, EventFilter, FilterFlag};
-use nix::sys::event::{EV_DELETE, EV_ADD, EV_ONESHOT, EV_CLEAR, EV_DISABLE, NOTE_TRIGGER};
+use nix::sys::event::{EV_ENABLE, EV_DELETE, EV_ADD, EV_ONESHOT, EV_CLEAR, EV_DISABLE, NOTE_TRIGGER};
 use libc::{uintptr_t, intptr_t};
 use nix::Result;
 
@@ -217,7 +217,7 @@ fn make_user_event(id: usize) -> KEvent {
     KEvent {
         ident: id as uintptr_t,
         filter: EventFilter::EVFILT_USER,
-        flags: EV_ADD | EV_CLEAR,
+        flags: EV_ADD | EV_CLEAR | EV_ENABLE,
         fflags: FilterFlag::empty(),
         data: 0,
         udata: id as UserData


### PR DESCRIPTION
Channels were not properly waking up the poller on kqueue based systems
when a send was made after a failing try_recv() call. It turns out that
on kqueue based systems EV_DISABLE (which is set on clearing of events)
is maintained even when an event is 're-added' with EV_ADD later, such
as during a user event trigger. The fix was to re-add the event with
EV_ADD | EV_ENABLE.

A regression test was added for the fix as well.

Bump version to 0.5.6