### PR TITLE
Update epoll and kqueue to remove oneshot behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amy"
-version = "0.5.7"
+version = "0.6.0"
 authors = ["Andrew J. Stone <andrew.j.stone.1@gmail.com>"]
 description = "Polling and Registration abstractions around kqueue and epoll for multithreaded async network programming"
 repository = "https://github.com/andrewjstone/amy"

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -197,7 +197,7 @@ fn make_changelist(sock_fd: RawFd, event: Event, user_data: UserData) -> Vec<KEv
     let mut ev = KEvent {
         ident: sock_fd as uintptr_t,
         filter: EventFilter::EVFILT_READ,
-        flags: EV_ADD | EV_ONESHOT, // Add+enable the event then remove it after triggering
+        flags: EV_ADD,
         fflags: FilterFlag::empty(),
         data: 0,
         udata: user_data

--- a/tests/multithread-example.rs
+++ b/tests/multithread-example.rs
@@ -21,7 +21,7 @@ use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::str;
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 
 const IP: &'static str = "127.0.0.1:10002";
 const DATA: &'static str = "Hello, World!\n";
@@ -30,22 +30,25 @@ const DATA: &'static str = "Hello, World!\n";
 fn primary_example() {
     let poller = Poller::new().unwrap();
     let registrar = poller.get_registrar();
-    let (tx, rx) = channel();
+    let (worker_tx, worker_rx) = channel();
+    let (client_tx, client_rx) = channel();
+    let (poller_tx, poller_rx) = channel();
 
     // Setup a listen socket in non-blocking mode
     let listener = TcpListener::bind(IP).unwrap();
     listener.set_nonblocking(true).unwrap();
 
+    let client_tx2 = client_tx.clone();
     let h1 = thread::spawn(move || {
-        run_worker(registrar, rx, listener);
+        run_worker(registrar, worker_rx, listener, client_tx2, poller_tx);
     });
 
     let h2 = thread::spawn(move || {
-        run_poller(poller, tx);
+        run_poller(poller, worker_tx, poller_rx, client_tx);
     });
 
     let h3 = thread::spawn(|| {
-        run_client();
+        run_client(client_rx);
     });
 
     for h in vec![h1, h2, h3] {
@@ -59,9 +62,12 @@ fn primary_example() {
 // This client drives the flow of the test. Lines of the client will be numbered to correspond with
 // sections of the poller and worker threads to describe what is happening. This should allow
 // understanding the asserts and flow of the test in context.
-fn run_client() {
+fn run_client(rx: Receiver<()>) {
     // 1) Connect to the non-blocking listening socket registered with the poller by the worker.
     let mut sock = TcpStream::connect(IP).unwrap();
+
+    // Wait for the worker to signal that it accepted the connection
+    let _ = rx.recv().unwrap();
 
     // 2 + 3) Write a single line of data. This data causes a read event in the poller, which gets
     // forwarded to the worker who will read it. The worker will then register the socket again with
@@ -75,10 +81,16 @@ fn run_client() {
     let mut buf = vec![0; DATA.len()];
     sock.read_exact(&mut buf).unwrap();
     assert_eq!(DATA, str::from_utf8(&buf).unwrap());
+
+    // Wait for the poller to signal that it is done
+    let _ = rx.recv().unwrap();
 }
 
 /// This thread runs the poller and forwards notifications to a worker thread.
-fn run_poller(mut poller: Poller, tx: Sender<Notification>) {
+fn run_poller(mut poller: Poller,
+              worker_tx: Sender<Notification>,
+              rx: Receiver<()>,
+              client_tx: Sender<()>) {
 
     // 1) Wait for a connection, and ensure we get one. We started listening in the worker thread.
     // The client has connected so we only get a single read event. Forward the notification to the
@@ -89,7 +101,11 @@ fn run_poller(mut poller: Poller, tx: Sender<Notification>) {
     assert_eq!(Event::Read, notification.event);
     assert_eq!(0, notification.id);
 
-    tx.send(notification).unwrap();
+    worker_tx.send(notification).unwrap();
+
+    // Wait for the worker to accept the socket so we don't get another notification for it
+    // This is only needed to make the test deterministic
+    let _ = rx.recv().unwrap();
 
     // 2) Wait for a read event signalling data from the client. Only one line of data from a single
     // client was sent, so there is only one read notification. There is some user data registered
@@ -101,7 +117,10 @@ fn run_poller(mut poller: Poller, tx: Sender<Notification>) {
     assert_eq!(1, notification.id);
 
     // Forward the notification to the worker
-    tx.send(notification).unwrap();
+    worker_tx.send(notification).unwrap();
+
+    // Wait for the worker to do the read
+    let _ = rx.recv().unwrap();
 
     // 3) The worker will read the data off the socket after it receives the read notification, and
     // register a write event on the same socket. The write socket buffer is empty because it's the
@@ -114,15 +133,26 @@ fn run_poller(mut poller: Poller, tx: Sender<Notification>) {
     assert_eq!(1, notification.id);
 
     // Forward the notification to the worker
-    tx.send(notification).unwrap();
+    worker_tx.send(notification).unwrap();
+
+    // Wait for the worker to do the write
+    let _ = rx.recv().unwrap();
 
     // 4) We should be done here. So poll and wait for a timeout.
     let notifications = poller.wait(1000).unwrap();
     assert_eq!(0, notifications.len());
+
+    // Signal the client to exit
+    // This will cause one more notification for the closed connection
+    client_tx.send(()).unwrap();
 }
 
 // This thread registers sockets and receives notifications from the poller when they are ready
-fn run_worker(registrar: Registrar, rx: Receiver<Notification>, listener: TcpListener) {
+fn run_worker(registrar: Registrar,
+              rx: Receiver<Notification>,
+              listener: TcpListener,
+              client_tx: Sender<()>,
+              poller_tx: Sender<()>) {
 
     let listener_id = registrar.register(&listener, Event::Read).unwrap();
     // This is the first registered socket, so it's Id is 1
@@ -141,6 +171,20 @@ fn run_worker(registrar: Registrar, rx: Receiver<Notification>, listener: TcpLis
     // This is the second registration of a socket, so it's Id is 2.
     assert_eq!(1, socket_id);
 
+    // Ensure when we accept again from the listener we get an ewouldblock
+    if let Err(e) = listener.accept() {
+        assert_eq!(ErrorKind::WouldBlock, e.kind());
+    }
+
+
+    // Signal the client that the the connection notification was received
+    // Note this isn't necessary in production, it's just here to make the test deterministic.
+    client_tx.send(()).unwrap();
+
+    // Signal the poller that the connection was accepted
+    // This also is only here to make the test deterministic
+    poller_tx.send(()).unwrap();
+
     // 2) Data was received on the socket from the client, the read event was handled by the poller
     // and forwarded to this worker.
     //
@@ -158,6 +202,9 @@ fn run_worker(registrar: Registrar, rx: Receiver<Notification>, listener: TcpLis
     let text = line_reader.iter_mut().next().unwrap().unwrap();
     assert_eq!(DATA.to_string(), text);
 
+    // Signal that the data was read to the poller
+    poller_tx.send(()).unwrap();
+
     // Re-Register the socket for writing so we can echo the data back to the client
     registrar.reregister(socket_id, &socket, Event::Write).unwrap();
 
@@ -171,6 +218,9 @@ fn run_worker(registrar: Registrar, rx: Receiver<Notification>, listener: TcpLis
     // Assume we have enough space in the outgoing buffer to write once
     // That's plausible in this test. Don't do this in production!
     assert_eq!(text.len(), bytes_written);
+
+    // Signal that the data was written to the poller
+    poller_tx.send(()).unwrap();
 
     // 4) The data was sent, and we are done here.
 }


### PR DESCRIPTION
Fix multithread test to correspond to this change

Update the getting started guide to reflect non-oneshot behavior

Fixes #14

bump version to 0.6.0