### PR TITLE
Add support for binary heap based timers instead of timerfd on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ repository = "https://github.com/andrewjstone/amy"
 keywords = ["async", "epoll", "kqueue", "eventloop", "timer"]
 license = "Apache-2.0"
 
+[features]
+# On linux, don't use timerfd. Instead store timers in a binary heap and utilize the epoll timeout.
+no_timerfd = []
+
 [dependencies]
 libc = "0.2"
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -76,6 +76,19 @@ impl<T: Debug> Sender<T> {
         }
         Ok(())
     }
+
+    pub fn try_clone(&self) -> io::Result<Sender<T>> {
+        Ok(Sender {
+            tx: self.tx.clone(),
+            user_event: self.user_event.try_clone()?,
+            pending: self.pending.clone()
+        })
+    }
+
+    // Return the poll id for the channel
+    pub fn get_id(&self) -> usize {
+        self.user_event.get_id()
+    }
 }
 
 #[derive(Debug)]
@@ -102,6 +115,19 @@ impl<T: Debug> SyncSender<T> {
             try!(self.user_event.trigger());
         }
         Ok(())
+    }
+
+    pub fn try_clone(&self) -> io::Result<SyncSender<T>> {
+        Ok(SyncSender {
+            tx: self.tx.clone(),
+            user_event: self.user_event.try_clone()?,
+            pending: self.pending.clone()
+        })
+    }
+
+    // Return the poll id for the channel
+    pub fn get_id(&self) -> usize {
+        self.user_event.get_id()
     }
 }
 

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -46,7 +46,7 @@ impl KernelPoller {
         let epfd = epoll_create()?;
         let registrations = Arc::new(AtomicUsize::new(0));
         let mut registrar = KernelRegistrar::new(epfd, registrations);
-        let (tx, rx) = channel(registrar.try_clone()?)?;
+        let (tx, rx) = channel(&mut registrar)?;
         registrar.timer_tx = Some(tx);
         Ok(KernelPoller {
             epfd: epfd,
@@ -62,7 +62,7 @@ impl KernelPoller {
         let epfd = epoll_create()?;
         let registrations = Arc::new(AtomicUsize::new(0));
         let mut registrar = KernelRegistrar::new(epfd, registrations);
-        let (tx, rx) = channel(registrar.try_clone()?)?;
+        let (tx, rx) = channel(&mut registrar)?;
         registrar.timer_tx = Some(tx);
         Ok(KernelPoller {
             epfd: epfd,

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -2,44 +2,65 @@ use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd};
 use std::slice;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::HashMap;
 use nix::sys::epoll::*;
-use nix::{Result};
 use nix::sys::eventfd::{eventfd, EFD_CLOEXEC, EFD_NONBLOCK};
 use libc;
-
+use std::io::{Result, Error, ErrorKind};
 use event::Event;
 use notification::Notification;
 use timer::Timer;
 use timerfd::TimerFd;
 use user_event::UserEvent;
+use channel::{channel, Sender, Receiver};
 
 static EPOLL_EVENT_SIZE: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub enum TimerMsg {
+    StartTimer {id: usize, timeout_ms: usize},
+    StartInterval {id: usize, timeout_ms: usize},
+    Cancel {id: usize}
+}
 
 pub struct KernelPoller {
     epfd: RawFd,
     registrar: KernelRegistrar,
-    events: Vec<EpollEvent>
+    events: Vec<EpollEvent>,
+    timer_rx: Receiver<TimerMsg>,
+    timers: HashMap<usize, Timer>,
+
+    #[cfg(no_timerfd)]
+    timers: ChannelTimers
 }
 
 impl KernelPoller {
     pub fn new() -> Result<KernelPoller> {
-        let epfd = try!(epoll_create());
+        let epfd = epoll_create()?;
         let registrations = Arc::new(AtomicUsize::new(0));
-        let registrar = KernelRegistrar::new(epfd, registrations);
+        let mut registrar = KernelRegistrar::new(epfd, registrations);
+        let (tx, rx) = channel(registrar.try_clone()?)?;
+        registrar.timer_tx = Some(tx);
         Ok(KernelPoller {
             epfd: epfd,
             registrar: registrar,
-            events: Vec::with_capacity(EPOLL_EVENT_SIZE)
+            events: Vec::with_capacity(EPOLL_EVENT_SIZE),
+            timer_rx: rx,
+            timers: HashMap::new()
         })
     }
 
-    pub fn get_registrar(&self) -> KernelRegistrar {
-        self.registrar.clone()
+    pub fn get_registrar(&self) -> Result<KernelRegistrar> {
+        self.registrar.try_clone()
     }
 
     /// Wait for epoll events. Return a list of notifications. Notifications contain user data
     /// registered with epoll_ctl which is extracted from the data member returned from epoll_wait.
     pub fn wait(&mut self, timeout_ms: usize) -> Result<Vec<Notification>> {
+
+        // We may have gotten a timer registration while awake, don't bother sleeping just to
+        // immediately wake up again.
+        self.receive_timer_messages()?;
 
         // Create a buffer to read events into
         let dst = unsafe {
@@ -51,28 +72,119 @@ impl KernelPoller {
         // Set the length of the vector to what was filled in by the call to epoll_wait
         unsafe { self.events.set_len(count); }
 
-        Ok(self.events.iter().map(|e| {
+        let mut timer_rx_notification = false;
+        let mut notifications = Vec::with_capacity(count);
+        let mut timer_ids = Vec::new();
+        for e in self.events.iter() {
             let id = e.data as usize;
-            Notification {
-                id: id,
-                event: event_from_kind(e.events)
+            if id == self.timer_rx.get_id() {
+                timer_rx_notification = true;
+            } else {
+                if self.timers.contains_key(&id) {
+                    timer_ids.push(id);
+                }
+                notifications.push(Notification {
+                    id: id,
+                    event: event_from_kind(e.events)
+                });
             }
-        }).collect())
+        }
+        if timer_rx_notification {
+            self.receive_timer_messages()?;
+        }
+
+        self.handle_timer_notifications(timer_ids)?;
+
+        Ok(notifications)
+    }
+
+    fn receive_timer_messages(&mut self) -> Result<()> {
+        while let Ok(msg) = self.timer_rx.try_recv() {
+            match msg {
+                TimerMsg::StartTimer {id, timeout_ms} => {
+                    let timer = self.set_timer(id, timeout_ms, false)?;
+                    self.timers.insert(id, timer);
+                },
+                TimerMsg::StartInterval {id, timeout_ms} => {
+                    let timer = self.set_timer(id, timeout_ms, true)?;
+                    self.timers.insert(id, timer);
+                },
+                TimerMsg::Cancel {id} => {
+                    // Removing the timer from the map will cause it to be dropped, which closes its fd
+                    // and subsequently removes it from epoll.
+                    self.timers.remove(&id);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_timer_notifications(&mut self, ids: Vec<usize>) -> Result<()> {
+        for id in ids {
+            let mut interval = false;
+            if let Some(timer) = self.timers.get(&id) {
+                if timer.interval {
+                    interval = true;
+                    timer.arm()?;
+                }
+            }
+            if !interval {
+                self.timers.remove(&id);
+            }
+        }
+        return Ok(())
+    }
+
+    fn set_timer(&self, id: usize, timeout: usize, recurring: bool) -> Result<Timer> {
+        let timer_fd = try!(TimerFd::new(timeout, recurring));
+        let info = EpollEvent {
+            events: kind_from_event(Event::Read),
+            data: id as u64
+        };
+        let fd = timer_fd.into_raw_fd();
+        match epoll_ctl(self.epfd, EpollOp::EpollCtlAdd, fd, &info) {
+            Ok(_) => Ok(Timer {fd: fd, interval: recurring}),
+            Err(e) => {
+                let _ = unsafe { libc::close(fd) };
+                Err(e.into())
+            }
+        }
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct KernelRegistrar {
     epfd: RawFd,
-    total_registrations: Arc<AtomicUsize>
+    total_registrations: Arc<AtomicUsize>,
+
+    // This sender is strictly used to send timer registrations and cancellations to the poller
+    //
+    // Since initializing a channel requires an existing KernelRegistrar, we must first
+    // create the channel with a registrar that has a `None` value for timer_tx. This is fine, as
+    // channels have no need to create timers.
+    timer_tx: Option<Sender<TimerMsg>>
 }
 
 impl KernelRegistrar {
     fn new(epfd: RawFd, registrations: Arc<AtomicUsize>) -> KernelRegistrar {
         KernelRegistrar {
             epfd: epfd,
-            total_registrations: registrations
+            total_registrations: registrations,
+            timer_tx: None
         }
+    }
+
+    pub fn try_clone(&self) -> Result<KernelRegistrar> {
+        let timer_tx = if let Some(ref tx) = self.timer_tx {
+            Some(tx.try_clone()?)
+        } else {
+            None
+        };
+        Ok(KernelRegistrar {
+            epfd: self.epfd,
+            total_registrations: self.total_registrations.clone(),
+            timer_tx: timer_tx
+        })
     }
 
     pub fn register<T: AsRawFd>(&self, sock: &T, event: Event) -> Result<usize> {
@@ -93,7 +205,7 @@ impl KernelRegistrar {
             events: kind_from_event(event),
             data: id as u64
         };
-        epoll_ctl(self.epfd, EpollOp::EpollCtlMod, sock_fd, &info)
+        Ok(epoll_ctl(self.epfd, EpollOp::EpollCtlMod, sock_fd, &info)?)
     }
 
     pub fn deregister<T: AsRawFd>(&self, sock: T) -> Result<()> {
@@ -103,7 +215,7 @@ impl KernelRegistrar {
             data: 0
         };
         let sock_fd = sock.as_raw_fd();
-        epoll_ctl(self.epfd, EpollOp::EpollCtlDel, sock_fd, &info)
+        Ok(epoll_ctl(self.epfd, EpollOp::EpollCtlDel, sock_fd, &info)?)
     }
 
     pub fn register_user_event(&mut self) -> Result<UserEvent> {
@@ -117,7 +229,7 @@ impl KernelRegistrar {
             Ok(_) => Ok(UserEvent {id: id, fd: fd}),
             Err(e) => {
                 let _ = unsafe { libc::close(fd) };
-                Err(e)
+                Err(e.into())
             }
         }
     }
@@ -126,38 +238,24 @@ impl KernelRegistrar {
         self.deregister(event)
     }
 
-    pub fn set_timeout(&self, timeout: usize) -> Result<Timer> {
-        self.set_timer(timeout, false)
-    }
-
-    pub fn set_interval(&self, timeout: usize) -> Result<Timer> {
-        self.set_timer(timeout, true)
-    }
-
-    pub fn cancel_timeout(&self, timer: Timer) -> Result<()> {
-        // It would be quite a weird situation for deregister to fail, but close to succeed.
-        // We must always close the fd though so it doesn't leak.
-        let fd = timer.as_raw_fd();
-        let res = self.deregister(timer);
-        let _ = unsafe { libc::close(fd) };
-        res
-    }
-
-    fn set_timer(&self, timeout: usize, recurring: bool) -> Result<Timer> {
-        let timer_fd = try!(TimerFd::new(timeout, recurring));
+    pub fn set_timeout(&self, timeout: usize) -> Result<usize> {
         let id = self.total_registrations.fetch_add(1, Ordering::SeqCst);
-        let info = EpollEvent {
-            events: kind_from_event(Event::Read),
-            data: id as u64
-        };
-        let fd = timer_fd.into_raw_fd();
-        match epoll_ctl(self.epfd, EpollOp::EpollCtlAdd, fd, &info) {
-            Ok(_) => Ok(Timer {id: id, fd: fd}),
-            Err(e) => {
-                let _ = unsafe { libc::close(fd) };
-                Err(e)
-            }
-        }
+        self.timer_tx.as_ref().unwrap().send(TimerMsg::StartTimer {id: id, timeout_ms: timeout})
+            .map_err(|_| Error::new(ErrorKind::BrokenPipe, "Channel receiver dropped"))?;
+        Ok(id)
+    }
+
+    pub fn set_interval(&self, timeout: usize) -> Result<usize> {
+        let id = self.total_registrations.fetch_add(1, Ordering::SeqCst);
+        self.timer_tx.as_ref().unwrap().send(TimerMsg::StartInterval {id: id, timeout_ms: timeout})
+            .map_err(|_| Error::new(ErrorKind::BrokenPipe, "Channel receiver dropped"))?;
+        Ok(id)
+    }
+
+    pub fn cancel_timeout(&self, timer_id: usize) -> Result<()> {
+        self.timer_tx.as_ref().unwrap().send(TimerMsg::Cancel {id: timer_id})
+            .map_err(|_| Error::new(ErrorKind::BrokenPipe, "Channel receiver dropped"))?;
+        Ok(())
     }
 }
 

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -1,16 +1,22 @@
-use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd};
+#[cfg(not(feature = "no_timerfd"))]
+use std::os::unix::io::IntoRawFd;
+#[cfg(not(feature = "no_timerfd"))]
+use timer::Timer;
+#[cfg(not(feature = "no_timerfd"))]
+use timerfd::TimerFd;
+#[cfg(not(feature = "no_timerfd"))]
+use std::collections::HashMap;
+
+use std::os::unix::io::{RawFd, AsRawFd};
 use std::slice;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::collections::HashMap;
 use nix::sys::epoll::*;
 use nix::sys::eventfd::{eventfd, EFD_CLOEXEC, EFD_NONBLOCK};
 use libc;
 use std::io::{Result, Error, ErrorKind};
 use event::Event;
 use notification::Notification;
-use timer::Timer;
-use timerfd::TimerFd;
 use user_event::UserEvent;
 use channel::{channel, Sender, Receiver};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod channel;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod epoll;
 #[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(not(feature = "no_timerfd"))]
 mod timerfd;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ mod epoll;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod timerfd;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(feature = "no_timerfd")]
+mod timer_heap;
+
 #[cfg(any(target_os = "bitrig", target_os = "dragonfly",
           target_os = "freebsd", target_os = "ios", target_os = "macos",
           target_os = "netbsd", target_os = "openbsd"))]

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -1,4 +1,4 @@
-use std::io::{Result, Error};
+use std::io::Result;
 
 use registrar::Registrar;
 use notification::Notification;
@@ -25,7 +25,7 @@ impl Poller {
     pub fn new() -> Result<Poller> {
         let inner = try!(KernelPoller::new());
         Ok(Poller {
-            registrar: Registrar::new(inner.get_registrar()),
+            registrar: Registrar::new(inner.get_registrar()?),
             inner: inner
         })
     }
@@ -33,12 +33,12 @@ impl Poller {
     /// Return a Registrar that can be used to register Sockets with a Poller.
     ///
     /// Registrars are cloneable and can be used on a different thread from the Poller.
-    pub fn get_registrar(&self) -> Registrar {
-        self.registrar.clone()
+    pub fn get_registrar(&self) -> Result<Registrar> {
+        self.registrar.try_clone()
     }
 
     /// Wait for notifications from the Poller
     pub fn wait(&mut self, timeout_ms: usize) -> Result<Vec<Notification>> {
-        self.inner.wait(timeout_ms).map_err(|e| Error::from(e))
+        self.inner.wait(timeout_ms)
     }
 }

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -112,8 +112,8 @@ impl Registrar {
     /// and this can fail.
     ///
     /// When a Receiver is dropped it will become unregistered.
-    pub fn channel<T: Debug>(&self) -> Result<(Sender<T>, Receiver<T>)> {
-        channel(self.inner.try_clone()?)
+    pub fn channel<T: Debug>(&mut self) -> Result<(Sender<T>, Receiver<T>)> {
+        channel(&mut self.inner)
     }
 
     /// Create a synchronous mpsc channel where the Receiver is registered with the kernel poller.
@@ -130,7 +130,7 @@ impl Registrar {
     /// since the Receiver is being registered with the kernel poller and this can fail.
     ///
     /// When a Receiver is dropped it will become unregistered.
-    pub fn sync_channel<T: Debug>(&self, bound: usize) -> Result<(SyncSender<T>, Receiver<T>)> {
-        sync_channel(self.inner.try_clone()?, bound)
+    pub fn sync_channel<T: Debug>(&mut self, bound: usize) -> Result<(SyncSender<T>, Receiver<T>)> {
+        sync_channel(&mut self.inner, bound)
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,8 +1,7 @@
 use std::os::unix::io::{RawFd, AsRawFd};
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::io::{Error, Result};
 use std::mem;
-#[cfg(any(target_os = "linux", target_os = "android"))]
 use libc;
 
 /// An opaque handle to a kernel timer instance.
@@ -13,18 +12,14 @@ use libc;
 #[derive(Debug)]
 pub struct Timer {
     #[doc(hidden)]
-    pub id: usize,
+    pub fd: RawFd,
 
     #[doc(hidden)]
-    pub fd: RawFd
+    pub interval: bool
 }
 
 
 impl Timer {
-    pub fn get_id(&self) -> usize {
-        self.id
-    }
-
     /// Re-arm a recurring timer.
     ///
     /// This method must be called when an interval timer notification is received. If not called,
@@ -37,40 +32,34 @@ impl Timer {
     /// will fire exactly at the interval specified originally. This just allows the kernel poller
     /// to received the timer event and send a notification. On epoll based systems if a timer has
     /// already fired because the timer period has elapsed, the kernel poller will be woken up
-    /// immediately after this call and a notification will be sent. Since this call is a no-op on
-    /// kqueue based systems, timer notifications will always be sent on time regardless of calls to
-    /// arm. This should not be a problem in practice as timers should be re-armed before the next
-    /// timer fires. Otherwise the timer interval is too short to be useful.
+    /// immediately after this call and a notification will be sent. This should not be a problem in
+    /// practice as timers should be re-armed before the next timer fires. Otherwise the timer
+    /// interval is too short to be useful.
     ///
-    /// Note that this method isn't strictly necessary for kqueue, but due to the semantics of epoll and
-    /// the usage of timerfd, it is required that this method be called. For portability, any users
-    /// should always call arm() when an interval timer notification is received.
+    /// On Linux timers are file descriptors registered with epoll. Since we use edge triggering we
+    /// need to read the file descriptors to change their state. Note that even if we used level
+    /// triggering we'd still need to do this, but for a different reason. The timer would fire
+    /// indefinitely as ready in the level triggered case, rather than never firing again as in the
+    /// edge triggered case.
     ///
-    pub fn arm(&self) {
-        self._arm();
-    }
-
-    // On Linux timers are file descriptors registered with epoll. Since we use edge triggering we
-    // need to read the file descriptors to change their state. Note that even if we used level
-    // triggering we'd still need to do this, but for a different reason. The timer would fire
-    // indefinitely as ready in the level triggered case, rather than never firing again as in the
-    // edge triggered case.
-    //
-    // Note that if epoll_wait on Linux returned the file descriptors that were ready we wouldn't
-    // need to push this call to the user. It's a sad state of affairs on Linux I'm afraid.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn _arm(&self) {
+    pub fn arm(&self) -> Result<()> {
         let buf: u64 = 0;
         unsafe {
             let ptr: *mut libc::c_void = mem::transmute(&buf);
-            libc::read(self.fd, ptr, 8);
+            if libc::read(self.fd, ptr, 8) < 0 {
+                return Err(Error::last_os_error());
+            }
+            Ok(())
         }
     }
+}
 
-    #[cfg(any(target_os = "bitrig", target_os = "dragonfly",
-              target_os = "freebsd", target_os = "ios", target_os = "macos",
-              target_os = "netbsd", target_os = "openbsd"))]
-    fn _arm(&self) {}
+impl Drop for Timer {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
 }
 
 impl AsRawFd for Timer {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -10,7 +10,7 @@ use libc;
 /// On Linux this contains a file descriptor created with
 /// [timerfd_create()](http://man7.org/linux/man-pages/man2/timerfd_create.2.html)
 /// On systems using kqueue, a file descriptor is not needed, so it is set to 0.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Timer {
     #[doc(hidden)]
     pub id: usize,

--- a/src/timer_heap.rs
+++ b/src/timer_heap.rs
@@ -1,0 +1,205 @@
+use std::collections::BinaryHeap;
+use std::cmp::{Ordering, Ord, PartialOrd, PartialEq};
+use std::time::{Instant, Duration};
+
+/// Store timers in a binary heap. Keep them sorted by which timer is going to expire first.
+pub struct TimerHeap {
+    timers: BinaryHeap<TimerEntry>
+}
+
+impl TimerHeap {
+    /// Create a new TimerHeap
+    pub fn new() -> TimerHeap {
+        TimerHeap {
+            timers: BinaryHeap::new()
+        }
+    }
+
+    /// Return the number of timers in the heap
+    pub fn len(&self) -> usize {
+        self.timers.len()
+    }
+
+    /// Insert a TimerEntry into the heap
+    pub fn insert(&mut self, entry: TimerEntry) {
+        self.timers.push(entry);
+    }
+
+    /// Remove a TimerEnry by Id
+    ///
+    /// Return the entry if it exists, None otherwise
+    ///
+    /// Note, in a large heap this is probably expensive.
+    pub fn remove(&mut self, id: usize) -> Option<TimerEntry> {
+        let mut popped = Vec::with_capacity(self.timers.len());
+        while let Some(entry) = self.timers.pop() {
+            if entry.id == id {
+                self.timers.extend(popped);
+                return Some(entry);
+            } else {
+                popped.push(entry);
+            }
+        }
+        self.timers.extend(popped);
+        None
+    }
+
+    /// Return the amount of time remaining (in ms) for the earliest expiring timer
+    /// Return `None` if there are no timers in the heap
+    pub fn time_remaining(&self) -> Option<u64> {
+        self._time_remaining(Instant::now())
+    }
+
+    /// A deterministically testable version of `time_remaining()`
+    fn _time_remaining(&self, now: Instant) -> Option<u64> {
+        self.timers.peek().map(|e| {
+            if now > e.expires_at {
+                return 0;
+            }
+            let duration = e.expires_at - now;
+            duration.as_secs()*1000 + (duration.subsec_nanos() / 1000000) as u64
+        })
+    }
+
+    /// Return all expired timer ids
+    ///
+    /// Any recurring timers will be re-added to the heap in the correct spot
+    pub fn expired(&mut self) -> Vec<usize> {
+        self._expired(Instant::now())
+    }
+
+    /// A deterministically testable version of `expired()`
+    pub fn _expired(&mut self, now: Instant) -> Vec<usize> {
+        let mut expired = Vec::new();
+        while let Some(mut popped) = self.timers.pop() {
+            if popped.expires_at <= now {
+                expired.push(popped.id);
+                if popped.recurring {
+                    // We use the expired_at time so we don't keep skewing later and later
+                    // by adding the duration to the current time.
+                    popped.expires_at += popped.duration;
+                    self.timers.push(popped);
+                }
+            } else {
+                self.timers.push(popped);
+                return expired;
+            }
+        }
+        expired
+    }
+}
+
+#[derive(Eq, Debug)]
+struct TimerEntry {
+    recurring: bool,
+    duration: Duration,
+    expires_at: Instant,
+    id: usize
+}
+
+impl TimerEntry {
+    fn new(id: usize, duration_ms: u64, recurring: bool) -> TimerEntry {
+        let duration = Duration::from_millis(duration_ms);
+        TimerEntry {
+            recurring: recurring,
+            duration: duration,
+            expires_at: Instant::now() + duration,
+            id: id
+        }
+    }
+}
+
+impl Ord for TimerEntry {
+    // Order the times backwards because we are sorting them via a max heap
+    fn cmp(&self, other: &TimerEntry) -> Ordering {
+        if self.expires_at > other.expires_at {
+            return Ordering::Less;
+        }
+        if self.expires_at < other.expires_at {
+            return Ordering::Greater;
+        }
+        Ordering::Equal
+    }
+}
+
+impl PartialOrd for TimerEntry {
+    fn partial_cmp(&self, other: &TimerEntry) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for TimerEntry {
+    fn eq(&self, other: &TimerEntry) -> bool {
+        self.expires_at == other.expires_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TimerHeap, TimerEntry};
+    use std::time::{Instant, Duration};
+
+    #[test]
+    fn time_remaining() {
+        let mut heap = TimerHeap::new();
+        let now = Instant::now();
+        let duration = Duration::from_millis(500);
+        let entry = TimerEntry {
+            id: 1,
+            recurring: false,
+            duration: duration,
+            expires_at: now + duration
+        };
+        heap.insert(entry);
+        assert_matches!(heap._time_remaining(now), Some(500));
+        assert_matches!(heap._time_remaining(now + duration), Some(0));
+        assert_matches!(heap._time_remaining(now + duration + Duration::from_millis(100)),
+                        Some(0));
+        assert_matches!(heap.remove(2), None);
+        let entry = heap.remove(1).unwrap();
+        assert_eq!(entry.id, 1);
+        assert_matches!(heap._time_remaining(now), None);
+    }
+
+    #[test]
+    fn expired_non_recurring() {
+        let mut heap = TimerHeap::new();
+        let now = Instant::now();
+        let duration = Duration::from_millis(500);
+        let entry = TimerEntry {
+            id: 1,
+            recurring: false,
+            duration: duration,
+            expires_at: now + duration
+        };
+        heap.insert(entry);
+        assert_eq!(heap._expired(now), vec![]);
+        let v = heap._expired(now + duration);
+        assert_eq!(v.len(), 1);
+        assert_eq!(heap.len(), 0);
+        assert_eq!(heap._expired(now + duration), vec![]);
+    }
+
+    #[test]
+    fn expired_recurring() {
+        let mut heap = TimerHeap::new();
+        let now = Instant::now();
+        let duration = Duration::from_millis(500);
+        let entry = TimerEntry {
+            id: 1,
+            recurring: true,
+            duration: duration,
+            expires_at: now + duration
+        };
+        heap.insert(entry);
+        assert_eq!(heap._expired(now), vec![]);
+        let v = heap._expired(now + duration);
+        assert_eq!(v.len(), 1);
+        assert_eq!(heap.len(), 1);
+        assert_eq!(heap._expired(now + duration + Duration::from_millis(1)), vec![]);
+        let v = heap._expired(now + duration + duration);
+        assert_eq!(v.len(), 1);
+        assert_eq!(heap.len(), 1);
+        assert_eq!(heap._expired(now + duration + duration), vec![]);
+    }
+}

--- a/src/timer_heap.rs
+++ b/src/timer_heap.rs
@@ -18,6 +18,7 @@ impl TimerHeap {
     }
 
     /// Return the number of timers in the heap
+    #[allow(dead_code)] // only used in tests right now
     pub fn len(&self) -> usize {
         self.timers.len()
     }
@@ -76,7 +77,6 @@ impl TimerHeap {
     /// next timer to fire.
     pub fn earliest_timeout(&self, user_timeout_ms: usize) -> usize {
         if let Some(remaining) = self.time_remaining() {
-            println!("TIME REMAINING = {:?}", remaining);
             if user_timeout_ms < remaining as usize {
                 user_timeout_ms
             } else {

--- a/tests/channel_test.rs
+++ b/tests/channel_test.rs
@@ -7,7 +7,7 @@ use amy::{Poller, Event};
 #[test]
 fn send_wakes_poller() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     // no notifications if nothing is registered
@@ -29,7 +29,7 @@ fn send_wakes_poller() {
 #[test]
 fn multiple_sends_wake_poller_once() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -48,7 +48,7 @@ fn multiple_sends_wake_poller_once() {
 #[test]
 fn send_before_poll_and_after_poll_but_before_recv_only_wakes_poller_once() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -72,7 +72,7 @@ fn send_before_poll_and_after_poll_but_before_recv_only_wakes_poller_once() {
 #[test]
 fn send_after_receive_after_poll_followed_by_recv_wakes_poller_again() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -99,7 +99,7 @@ fn send_after_receive_after_poll_followed_by_recv_wakes_poller_again() {
 #[test]
 fn send_after_receive_after_poll_followed_by_recv_until_err_doesnt_wake_polller_again() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -126,7 +126,7 @@ fn send_after_receive_after_poll_followed_by_recv_until_err_doesnt_wake_polller_
 /// Ensure that when the user event is cleared that retriggering it wakes the poller
 fn send_poll_receive_twice_then_send_poll_receive_once() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -148,7 +148,7 @@ fn send_poll_receive_twice_then_send_poll_receive_once() {
 #[test]
 fn simple_sync_channel_test() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.sync_channel(1).unwrap();
 
     // no notifications if nothing is registered

--- a/tests/channel_test.rs
+++ b/tests/channel_test.rs
@@ -7,7 +7,7 @@ use amy::{Poller, Event};
 #[test]
 fn send_wakes_poller() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     // no notifications if nothing is registered
@@ -29,7 +29,7 @@ fn send_wakes_poller() {
 #[test]
 fn multiple_sends_wake_poller_once() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -48,7 +48,7 @@ fn multiple_sends_wake_poller_once() {
 #[test]
 fn send_before_poll_and_after_poll_but_before_recv_only_wakes_poller_once() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -72,7 +72,7 @@ fn send_before_poll_and_after_poll_but_before_recv_only_wakes_poller_once() {
 #[test]
 fn send_after_receive_after_poll_followed_by_recv_wakes_poller_again() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -99,7 +99,7 @@ fn send_after_receive_after_poll_followed_by_recv_wakes_poller_again() {
 #[test]
 fn send_after_receive_after_poll_followed_by_recv_until_err_doesnt_wake_polller_again() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -126,7 +126,7 @@ fn send_after_receive_after_poll_followed_by_recv_until_err_doesnt_wake_polller_
 /// Ensure that when the user event is cleared that retriggering it wakes the poller
 fn send_poll_receive_twice_then_send_poll_receive_once() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -148,7 +148,7 @@ fn send_poll_receive_twice_then_send_poll_receive_once() {
 #[test]
 fn simple_sync_channel_test() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar().unwrap();
     let (tx, rx) = registrar.sync_channel(1).unwrap();
 
     // no notifications if nothing is registered

--- a/tests/timer_test.rs
+++ b/tests/timer_test.rs
@@ -17,13 +17,13 @@ const FINAL_POLL_TIMEOUT: usize = 250; // ms
 #[test]
 fn test_set_timeout() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
+    let registrar = poller.get_registrar().unwrap();
     let now = Instant::now();
-    let timer = registrar.set_timeout(TIMEOUT).unwrap();
+    let timer_id = registrar.set_timeout(TIMEOUT).unwrap();
     let notifications = poller.wait(POLL_TIMEOUT).unwrap();
     let elapsed = now.elapsed();
     assert_eq!(1, notifications.len());
-    assert_eq!(timer.get_id(), notifications[0].id);
+    assert_eq!(timer_id, notifications[0].id);
     assert!(elapsed > Duration::from_millis(TIMEOUT as u64));
     assert!(elapsed < Duration::from_millis(POLL_TIMEOUT as u64));
 }
@@ -31,19 +31,18 @@ fn test_set_timeout() {
 #[test]
 fn test_set_interval() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar();
-    let timer = registrar.set_interval(TIMEOUT).unwrap();
+    let registrar = poller.get_registrar().unwrap();
+    let timer_id = registrar.set_interval(TIMEOUT).unwrap();
     let now = Instant::now();
     for i in 1..5 {
         let notifications = poller.wait(POLL_TIMEOUT).unwrap();
-        timer.arm();
         let elapsed = now.elapsed();
         assert_eq!(1, notifications.len());
-        assert_eq!(timer.get_id(), notifications[0].id);
+        assert_eq!(timer_id, notifications[0].id);
         assert!(elapsed > Duration::from_millis(i*TIMEOUT as u64));
         assert!(elapsed < Duration::from_millis(POLL_TIMEOUT as u64));
     }
-    assert!(registrar.cancel_timeout(timer).is_ok());
+    assert!(registrar.cancel_timeout(timer_id).is_ok());
     let now = Instant::now();
     let notifications = poller.wait(FINAL_POLL_TIMEOUT).unwrap();
     assert!(now.elapsed() > Duration::from_millis(FINAL_POLL_TIMEOUT as u64));


### PR DESCRIPTION
If the `no_timerfd` feature is used, the TimerHeap will be used for
maintaining timeouts and will properly set the epoll timeout so that
they are fired at the proper time.

###	All timers are now managed by the poller on linux  …
A new timer channel was created so that timer_ids could be created by the user
at the registrars but sent directly to the poller thread for actual creation of
timerfd file descriptors and registration with epoll. These timers are also tracked
so that when a notification occurs they can be re-armed in the poller rather than
requiring the client of amy to do this. This simplifies the API and helps prevent
mistakes where interval timers don't fire because the user did not re-arm them.

While this change makes the API more ergonomic, it is slightly more expensive in that
it requires a channel send and extra tracking and checking at the poller. This seems to
be a reasonable tradeoff however, as registering timers should be very infrequent. Timers
should only be coarse grained and used to drive timer wheels for finer granularity and
greater scale. The tracking is unfortunate, but cost may be mitigated in the future by
storing the type of notification in the high bits of the IDs, so that extra hashmap
lookups are not required on each poll result.

All of the above is very useful, but the change was primarily motivated in order to
provide a method for creating timers that do not require timerfd usage. This new channel
can be used to instruct the poller to adjust it's timeouts to the minimum timer expiry so
that this feature can be implemented. The reason for implementation is that some linux
emulation layers and old versions of linux do not support timerfd.

Additionally, there were some other relatively minor changes:
 * Timers are now just usize IDs like other notifications from a user POV
 * Registrars are no longer clone, as they must clone an amy channel, which itself
   requires a UserEvent clone which requires a `libc::dup` call which can fail. There
   is a new `try_clone(&self)` method as a replacement.
 * The timer is now only internally used by epoll and it's structure is different.
 * All errorable return types from KernelPoller, channels, timers etc.. are `io::Result`
   and no longer `nix::Result`
 * Tests were fixed to reflect the new API

### Make channel eventfd usage safer on Linux
Previously, the channel sender and receiver contained a copy of the same RawFd.
If the channel was closed this RawFd would leak. Fixing that leak by calling
close() on the fd could actually result in erroneous behavior. Eventfd files
signal user events via reading and writing. If the Fd was closed and re-used by
the kernel, writing to it with the sender could potentially overwrite an unrelated
file. We now do the right thing and dup the fd so that the race condition doesn't exist.
When all senders and receivers are dropped, all duplicate fds are closed and the
underlying file is cleaned up.