### PR TITLE
Don't require ownership transfer for deregistration

### DIFF
--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -314,7 +314,7 @@ impl KernelRegistrar {
         Ok(epoll_ctl(self.epfd, EpollOp::EpollCtlMod, sock_fd, &info)?)
     }
 
-    pub fn deregister<T: AsRawFd>(&self, sock: T) -> Result<()> {
+    pub fn deregister<T: AsRawFd>(&self, sock: &T) -> Result<()> {
         // info is unused by epoll on delete operations
         let info = EpollEvent {
             events: EpollEventKind::empty(),
@@ -340,7 +340,7 @@ impl KernelRegistrar {
         }
     }
 
-    pub fn deregister_user_event(&mut self, event: UserEvent) -> Result<()> {
+    pub fn deregister_user_event(&mut self, event: &UserEvent) -> Result<()> {
         self.deregister(event)
     }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -120,7 +120,7 @@ impl KernelRegistrar {
         Ok(())
     }
 
-    pub fn deregister<T: AsRawFd>(&self, sock: T) -> Result<()> {
+    pub fn deregister<T: AsRawFd>(&self, sock: &T) -> Result<()> {
         let sock_fd = sock.as_raw_fd();
         let mut changes = make_changelist(sock_fd, Event::Both, 0);
         for e in changes.iter_mut() {

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -51,12 +51,9 @@ impl Registrar {
 
     /// Remove a socket from a Poller
     ///
-    /// Note that ownership of the socket is taken here. Sockets should only be deregistered when
-    /// the caller is done with them.
-    ///
     /// Will return an error if the socket is not present in the poller when using epoll. Returns no
     /// error with kqueue.
-    pub fn deregister<T: AsRawFd>(&self, sock: T) -> Result<()> {
+    pub fn deregister<T: AsRawFd>(&self, sock: &T) -> Result<()> {
         self.inner.deregister(sock)
     }
 


### PR DESCRIPTION
As per #22, I've changed the API of deregister to no longer require ownership transfer.