### PR TITLE
Make Registrar Clone again

### DIFF
--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -79,10 +79,8 @@ impl KernelPoller {
         })
     }
 
-
-
-    pub fn get_registrar(&self) -> Result<KernelRegistrar> {
-        self.registrar.try_clone()
+    pub fn get_registrar(&self) -> KernelRegistrar {
+        self.registrar.clone()
     }
 
     /// Wait for epoll events. Return a list of notifications. Notifications contain user data
@@ -258,7 +256,7 @@ impl KernelPoller {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KernelRegistrar {
     epfd: RawFd,
     total_registrations: Arc<AtomicUsize>,
@@ -278,19 +276,6 @@ impl KernelRegistrar {
             total_registrations: registrations,
             timer_tx: None
         }
-    }
-
-    pub fn try_clone(&self) -> Result<KernelRegistrar> {
-        let timer_tx = if let Some(ref tx) = self.timer_tx {
-            Some(tx.try_clone()?)
-        } else {
-            None
-        };
-        Ok(KernelRegistrar {
-            epfd: self.epfd,
-            total_registrations: self.total_registrations.clone(),
-            timer_tx: timer_tx
-        })
     }
 
     pub fn register<T: AsRawFd>(&self, sock: &T, event: Event) -> Result<usize> {

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -40,8 +40,8 @@ impl KernelPoller {
     }
 
     // This will always succeed. We implement it this way for api compatibility with epoll.
-    pub fn get_registrar(&self) -> Result<KernelRegistrar> {
-        Ok(self.registrar.clone())
+    pub fn get_registrar(&self) -> KernelRegistrar {
+        self.registrar.clone()
     }
 
     // Wait for kevents and return a list of Notifications. Coalesce reads and writes for the same
@@ -98,11 +98,6 @@ impl KernelRegistrar {
             kqueue: kq,
             total_registrations: registrations
         }
-    }
-
-    // This will always succeed. We implement this to provide api compatibility with epoll.
-    pub fn try_clone(&self) -> Result<KernelRegistrar> {
-        Ok(self.clone())
     }
 
     pub fn register<T: AsRawFd>(&self, sock: &T, event: Event) -> Result<usize> {

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -23,9 +23,9 @@ pub struct Poller {
 
 impl Poller {
     pub fn new() -> Result<Poller> {
-        let inner = try!(KernelPoller::new());
+        let inner = KernelPoller::new()?;
         Ok(Poller {
-            registrar: Registrar::new(inner.get_registrar()?),
+            registrar: Registrar::new(inner.get_registrar()),
             inner: inner
         })
     }
@@ -33,8 +33,8 @@ impl Poller {
     /// Return a Registrar that can be used to register Sockets with a Poller.
     ///
     /// Registrars are cloneable and can be used on a different thread from the Poller.
-    pub fn get_registrar(&self) -> Result<Registrar> {
-        self.registrar.try_clone()
+    pub fn get_registrar(&self) -> Registrar {
+        self.registrar.clone()
     }
 
     /// Wait for notifications from the Poller

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -17,7 +17,7 @@ pub use kqueue::KernelRegistrar;
 /// A Registrar is tied to a Poller of the same type, and registers sockets and unique IDs for those
 /// sockets as userdata that can be waited on by the poller. A Registar should only be retrieved via
 /// a call to Poller::get_registrar(&self), and not created on it's own.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Registrar {
     inner: KernelRegistrar
 }
@@ -29,12 +29,6 @@ impl Registrar {
         Registrar {
             inner: inner
         }
-    }
-
-    pub fn try_clone(&self) -> Result<Registrar> {
-        Ok(Registrar {
-            inner: self.inner.try_clone()?
-        })
     }
 
     /// Register a socket for a given event type, with a Poller and return it's unique ID

--- a/src/user_event.rs
+++ b/src/user_event.rs
@@ -29,19 +29,6 @@ impl UserEvent {
         self.id
     }
 
-    pub fn try_clone(&self) -> Result<UserEvent> {
-        unsafe {
-            let fd = libc::dup(self.fd);
-            if fd < 0 {
-                return Err(Error::last_os_error());
-            }
-            Ok(UserEvent {
-                id: self.id,
-                fd: fd
-            })
-        }
-    }
-
     pub fn clear(&self) -> Result<()> {
         let buf: u64 = 0;
         unsafe {
@@ -104,11 +91,6 @@ pub struct UserEvent {
 impl UserEvent {
     pub fn get_id(&self) -> usize {
         self.id
-    }
-
-    // This call always succeeds. It returns a result for API compatibility with epoll.
-    pub fn try_clone(&self) -> Result<UserEvent> {
-        Ok(self.clone())
     }
 
     pub fn clear(&self) -> Result<()> {

--- a/tests/channel_test.rs
+++ b/tests/channel_test.rs
@@ -7,7 +7,7 @@ use amy::{Poller, Event};
 #[test]
 fn send_wakes_poller() {
     let mut poller = Poller::new().unwrap();
-    let mut registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar();
     let (tx, rx) = registrar.channel().unwrap();
 
     // no notifications if nothing is registered
@@ -29,7 +29,7 @@ fn send_wakes_poller() {
 #[test]
 fn multiple_sends_wake_poller_once() {
     let mut poller = Poller::new().unwrap();
-    let mut registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -48,7 +48,7 @@ fn multiple_sends_wake_poller_once() {
 #[test]
 fn send_before_poll_and_after_poll_but_before_recv_only_wakes_poller_once() {
     let mut poller = Poller::new().unwrap();
-    let mut registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -72,7 +72,7 @@ fn send_before_poll_and_after_poll_but_before_recv_only_wakes_poller_once() {
 #[test]
 fn send_after_receive_after_poll_followed_by_recv_wakes_poller_again() {
     let mut poller = Poller::new().unwrap();
-    let mut registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -99,7 +99,7 @@ fn send_after_receive_after_poll_followed_by_recv_wakes_poller_again() {
 #[test]
 fn send_after_receive_after_poll_followed_by_recv_until_err_doesnt_wake_polller_again() {
     let mut poller = Poller::new().unwrap();
-    let mut registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -126,7 +126,7 @@ fn send_after_receive_after_poll_followed_by_recv_until_err_doesnt_wake_polller_
 /// Ensure that when the user event is cleared that retriggering it wakes the poller
 fn send_poll_receive_twice_then_send_poll_receive_once() {
     let mut poller = Poller::new().unwrap();
-    let mut registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar();
     let (tx, rx) = registrar.channel().unwrap();
 
     tx.send("a").unwrap();
@@ -148,7 +148,7 @@ fn send_poll_receive_twice_then_send_poll_receive_once() {
 #[test]
 fn simple_sync_channel_test() {
     let mut poller = Poller::new().unwrap();
-    let mut registrar = poller.get_registrar().unwrap();
+    let mut registrar = poller.get_registrar();
     let (tx, rx) = registrar.sync_channel(1).unwrap();
 
     // no notifications if nothing is registered

--- a/tests/multithread-example.rs
+++ b/tests/multithread-example.rs
@@ -29,7 +29,7 @@ const DATA: &'static str = "Hello, World!\n";
 #[test]
 fn primary_example() {
     let poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let registrar = poller.get_registrar();
     let (worker_tx, worker_rx) = channel();
     let (client_tx, client_rx) = channel();
     let (poller_tx, poller_rx) = channel();

--- a/tests/timer_test.rs
+++ b/tests/timer_test.rs
@@ -17,7 +17,7 @@ const FINAL_POLL_TIMEOUT: usize = 250; // ms
 #[test]
 fn test_set_timeout() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let registrar = poller.get_registrar();
     let now = Instant::now();
     let timer_id = registrar.set_timeout(TIMEOUT).unwrap();
     let notifications = poller.wait(POLL_TIMEOUT).unwrap();
@@ -31,7 +31,7 @@ fn test_set_timeout() {
 #[test]
 fn test_set_interval() {
     let mut poller = Poller::new().unwrap();
-    let registrar = poller.get_registrar().unwrap();
+    let registrar = poller.get_registrar();
     let timer_id = registrar.set_interval(TIMEOUT).unwrap();
     let now = Instant::now();
     for i in 1..5 {


### PR DESCRIPTION
Use an Arc around UserEvent inside channel rather than duping file
descriptors. This way, cloning won't ever fail.