### PR TITLE
Run travis tests on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ rust:
   - beta
   - nightly
 matrix:
+  include:
+    - os: osx
+      rust: stable
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
This adds OSX tests to stable rust.